### PR TITLE
User Area overflow bug fix

### DIFF
--- a/UserAreaFix.css
+++ b/UserAreaFix.css
@@ -1,0 +1,9 @@
+.avatarWrapper-1B9FTW.withTagAsButton-OsgQ9L {
+    min-width: 0;
+    transition: 0.2s;
+}
+
+.avatarWrapper-1B9FTW.withTagAsButton-OsgQ9L:hover {
+    min-width: 120px;
+    transition: 0.2s;
+}

--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -26,4 +26,14 @@ module.exports = ({ getSetting, toggleSetting, plugin }) => <>
    >
       Play toggle sound
    </SwitchItem>
+   <SwitchItem
+      value={getSetting('fixUserArea', true)}
+      onChange={() => {
+         toggleSetting('fixUserArea', true)
+         plugin._unload();
+         plugin._load();
+      }}
+   >
+      Fix User Area overflow
+   </SwitchItem>
 </>;

--- a/index.jsx
+++ b/index.jsx
@@ -28,6 +28,11 @@ module.exports = class GameActivityToggle extends Plugin {
       } else {
          this.patchAccountContainer();
       }
+
+      if (this.settings.get('fixUserArea', true)) {
+         console.log("Applying fix")
+         this.loadStylesheet('./UserAreaFix.css')
+      }
    }
 
    patchStatusPicker() {

--- a/index.jsx
+++ b/index.jsx
@@ -30,7 +30,6 @@ module.exports = class GameActivityToggle extends Plugin {
       }
 
       if (this.settings.get('fixUserArea', true)) {
-         console.log("Applying fix")
          this.loadStylesheet('./UserAreaFix.css')
       }
    }


### PR DESCRIPTION
Added a CSS fix for the User Area overflow bug (resolves #10)
It's togglable (on by default) in the settings so you can turn it off if it conflicts your theme

![fix](https://user-images.githubusercontent.com/34186403/180647640-74ac0998-e4fd-459e-a3d0-f4320c8f59d9.gif)
![settings](https://user-images.githubusercontent.com/34186403/180647644-8238cc57-b216-46e7-bcb5-977753e5078f.png)

